### PR TITLE
feat: publish CLI to npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        node-version: [22.x, 24.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run build
+      - run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: release
+on:
+  workflow_dispatch:
+    inputs:
+      semver:
+        description: The semver to use
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+  pull_request:
+    types: [closed]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: nearform-actions/optic-release-automation-action@v4
+        with:
+          publish-mode: oidc
+          semver: ${{ github.event.inputs.semver }}
+          build-command: |
+            npm ci
+            npm run build

--- a/package.json
+++ b/package.json
@@ -3,6 +3,25 @@
   "version": "0.1.0",
   "description": "Tracebound CLI: deterministic primitives for the Tracebound agent-improvement loop.",
   "type": "module",
+  "license": "MIT",
+  "author": "NearForm Ltd (https://www.nearform.com)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nearform/tracebound.git"
+  },
+  "homepage": "https://github.com/nearform/tracebound#readme",
+  "bugs": {
+    "url": "https://github.com/nearform/tracebound/issues"
+  },
+  "keywords": [
+    "cli",
+    "llm",
+    "agent",
+    "traces",
+    "observability",
+    "evals",
+    "failure-modes"
+  ],
   "bin": {
     "tracebound": "./dist/cli.js"
   },
@@ -14,10 +33,15 @@
   "engines": {
     "node": ">=22.6.0"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node scripts/postbuild.js",
     "clean": "rm -rf dist",
     "prepare": "npm run build",
+    "prepublishOnly": "npm run typecheck && npm test",
     "test": "node --test src/__tests__/*.test.ts",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
# Publish CLI to npm

Closes #4

## What

Makes `@tracebound/cli` publishable to the public npm registry and adds the release + CI automation, following the NearForm OSS convention (mirrors [`nearform/fast-jwt`](https://github.com/nearform/fast-jwt)).

The package was already structurally close to publish-ready (`bin`, `files`, `prepare` build). This PR fills the gaps.

## Changes

### `package.json`
- **`publishConfig: { access: "public", provenance: true }`** — required: a scoped package (`@tracebound/*`) defaults to restricted, so without this the first publish fails. `provenance` is emitted via OIDC.
- Added npm metadata: `license`, `author`, `repository`, `homepage`, `bugs`, `keywords`.
- Added `prepublishOnly` (`typecheck && test`) — gates a publish on a green typecheck and test run.

### `.github/workflows/release.yml` (new)
- Uses `nearform-actions/optic-release-automation-action@v4` with `publish-mode: oidc` (trusted publishing — no `NPM_TOKEN` stored in the repo, provenance included).
- Triggered by manual `workflow_dispatch` (choose patch/minor/major) and the release-PR `closed` flow.

### `.github/workflows/ci.yml` (new)
- Runs `typecheck`, `build` and `test` on every PR and on push to `master`, across Node `22.x` and `24.x` (matches the package's `engines: >=22.6.0`).

## Verification (local)

- `npm run typecheck` — passes
- `npm test` — 88/88 pass
- `npm publish --dry-run` — reports `public access`
- `npm pack --dry-run` — tarball contains `dist/`, `templates/`, `README.md`, `LICENSE`, `package.json` (15 files)

## Follow-ups before the first release (ops, outside this repo)

These are prerequisites for the release workflow to actually publish — they are **not** code changes:

1. **npm scope + trusted publisher**: the `@tracebound` org/scope must exist on npm, with a trusted publisher configured for `nearform/tracebound` (required for OIDC publishing).
2. **GitHub `production` environment**: `release.yml` runs in the `production` environment (as fast-jwt does); it must exist in the repo settings, or that line should be removed.
3. **`author` field**: set to `NearForm Ltd` here, but the `LICENSE` copyright holder is `Alfonso Graziano` — confirm the intended value.