### PR TITLE
docs(analyze-traces): clarify feedback comments are not ground truth

### DIFF
--- a/skills/analyze-traces/SKILL.md
+++ b/skills/analyze-traces/SKILL.md
@@ -9,6 +9,8 @@ Tracebound's trace-clustering pass. Operates on a single agent at a time. Takes 
 
 This skill is a closed-loop workflow over the user's working tree. It does not commit, push, or open PRs — it leaves the tree ready and stops. The user reviews the diff and decides what to ship. Recovery from a bad write is the user's working tree under git; the skill does not snapshot.
 
+> **⚠️ Feedback comments are NOT ground truth.** A trace's user/SME `feedback[].comment` is a *signal*, primarily written for the human reviewer — it flags that something felt wrong, and often guesses at why. Read it and factor it in, but never treat it as the authoritative diagnosis. The commenter may be mistaken, vague, or describe a symptom rather than the cause. Always confirm the actual root cause yourself by reading the raw trace on demand — inspect the **tool calls and tool responses**, the messages, and the metadata (see §4 Step 1) — before you classify. When the comment and the trace evidence disagree, the trace evidence wins. Do the deep analysis; do not shortcut to the comment's conclusion.
+
 ## Inputs
 
 - **agent_name (required)** — the agent whose traces to analyze. If the user did not specify one, run `npx tracebound agents` and ask which agent to operate on. Stop until the user confirms. Print "Operating on agent: `<agent_name>`" before doing any other work.


### PR DESCRIPTION
## What

Adds a warning callout near the top of the `analyze-traces` skill (`skills/analyze-traces/SKILL.md`) making explicit that a trace's user/SME `feedback[].comment` is a **signal**, not ground truth.

## Why

The comment is written primarily for the human reviewer — it flags that something felt wrong and often guesses at why. The commenter may be mistaken, vague, or describe a symptom rather than the cause. Left implicit, the classifier can shortcut to the comment's conclusion instead of doing the deep analysis the skill relies on.

## The rule

- Read the comment and factor it in, but always confirm the actual root cause from the raw trace evidence — tool calls, tool responses, messages, and metadata (see §4 Step 1).
- When the comment and the trace evidence disagree, **the trace evidence wins**.

Single-file, additive change (2 insertions, no removals). Reinforces guidance already present in §4 Step 1 and promotes it to an up-front principle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)