### PR TITLE
chore(deps): consolidate Dependabot updates

### DIFF
--- a/examples/mastra-support-bot/package-lock.json
+++ b/examples/mastra-support-bot/package-lock.json
@@ -1206,9 +1206,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -3171,21 +3171,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -3218,9 +3231,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4306,15 +4319,15 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -4333,7 +4346,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -4371,9 +4384,9 @@
       }
     },
     "node_modules/express/node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4393,22 +4406,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/express/node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -4450,22 +4447,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/express/node_modules/raw-body": {
       "version": "2.5.3",
@@ -4584,9 +4565,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -5022,9 +5003,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.15",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5119,9 +5100,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -5385,9 +5366,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -7128,9 +7109,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -7706,9 +7687,9 @@
       }
     },
     "node_modules/serve-handler/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7850,9 +7831,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8289,17 +8270,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/type-is/node_modules/mime-db": {
@@ -8740,9 +8738,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
Consolidates the 7 open Dependabot PRs into a single reviewable change. All 7 target
`examples/mastra-support-bot`, and all 7 are transitive-only bumps — every one of them
changes `examples/mastra-support-bot/package-lock.json` and nothing else. No
`package.json` in this repo is modified by this PR.

The lockfile was re-derived rather than merged, so the dependency graph stays coherent.
Every package whose resolved version moves is listed below; there are no others.

## Included updates (npm) — the 7 PRs' declared targets

| Package | Path in tree | From | To | Bump | Supersedes | Status |
|---|---|---|---|---|---|---|
| `hono` | `node_modules/hono` | 4.12.15 | 4.13.1 | minor | #27 | ✅ pass |
| `fast-uri` | `node_modules/fast-uri` | 3.1.0 | 3.1.5 | patch | #26 | ✅ pass |
| `ip-address` | `node_modules/ip-address` | 10.2.0 | 10.4.0 | minor | #24 | ✅ pass |
| `shell-quote` | `node_modules/shell-quote` | 1.8.3 | 1.10.0 | minor | #21 | ✅ pass |
| `body-parser` | `node_modules/body-parser` | 2.2.2 | 2.3.0 | minor | #20 | ✅ pass |
| `body-parser` | `node_modules/express/node_modules/body-parser` | 1.20.5 | 1.20.6 | patch | #20 | ✅ pass |
| `ws` | `node_modules/ws` | 8.20.0 | 8.21.1 | minor | #19 | ✅ pass |
| `qs` | `node_modules/qs` | 6.15.1 | 6.15.2 | patch | #5 | ✅ pass |
| `express` | `node_modules/express` | 4.22.1 | 4.22.2 | patch | #5 | ✅ pass |

`#20` and `#5` are Dependabot's multi-dependency PRs; each contributes two rows. `#20`
bumps both copies of `body-parser` in the tree (the 1.x one nested under `express` 4.x
and the hoisted 2.x one). `#5` bumps `qs` and `express` together because they have to
move together — see below.

## Also included: what closing #5 would otherwise strand

`#5` has been open since May and picked up a conflict-resolution merge from
`nearform-lastlight[bot]` in August (`662d251`). Because this example pins
`@mastra/core`, `@mastra/libsql` and `mastra` to `latest`, that merge re-resolved the
whole tree, so #5's *head* now carries four security fixes beyond its declared
`qs`/`express` target. Closing #5 as superseded would forfeit them, so they are folded
in here:

| Package | Path in tree | From | To | Closes |
|---|---|---|---|---|
| `js-yaml` | `node_modules/js-yaml` | 3.14.2 | 3.15.1 | GHSA-52cp-r559-cp3m, GHSA-h67p-54hq-rp68, GHSA-5p4m-2wfm-xmqj |
| `@hono/node-server` | `node_modules/@hono/node-server` | 1.19.14 | 1.19.17 | GHSA-frvp-7c67-39w9 |
| `brace-expansion` | `node_modules/serve-handler/node_modules/brace-expansion` | 1.1.14 | 1.1.18 | GHSA-3jxr-9vmj-r5cp (1.x) |
| `brace-expansion` | `node_modules/brace-expansion` | 2.1.0 | 2.1.4 | GHSA-3jxr-9vmj-r5cp (2.x) |

`js-yaml`, `@hono/node-server` and the 1.x `brace-expansion` are the exact versions #5's
head resolves. The 2.x `brace-expansion` is not: #5's head has 5.0.9, which this branch
cannot take. #5's head also moved `minimatch` 9.0.9 → 10.2.6 (`brace-expansion@^5.0.8`)
and `readdir-glob` 1.1.3 → 3.0.0; this branch keeps master's `minimatch@9.0.9`
(`brace-expansion@^2.0.2`) and `readdir-glob`'s nested `minimatch@5.1.9` (`^2.0.1`), which
5.0.9 does not satisfy. Taking it would mean a `minimatch` 9 → 10 major that no Dependabot
PR asks for. 2.1.4 is the current 2.x release and is above 2.1.2, the first patched
version for GHSA-3jxr-9vmj-r5cp. All four extras stay within their parents' existing
ranges; no manifest change.

## Transitive consequences (not requested by any PR)

| Package | Path | Change | Required by |
|---|---|---|---|
| `type-is` | `node_modules/type-is` | 2.0.1 → 2.1.0 | `body-parser@2.3.0` requires `type-is@^2.1.0` (was `^2.0.1`) |
| `content-type` | `node_modules/body-parser/node_modules/content-type` | added @2.1.0 | `body-parser@2.3.0` requires `content-type@^2.0.0`; the hoisted copy is 1.0.5 because `express` 4.x pins `~1.0.4` |
| `content-type` | `node_modules/type-is/node_modules/content-type` | added @2.1.0 | `type-is@2.1.0` requires `content-type@^2.0.0`, same reason |
| `qs` | `node_modules/express/node_modules/qs` | removed @6.14.2 | deduped into the hoisted `qs@6.15.2` |
| `qs` | `node_modules/express/node_modules/body-parser/node_modules/qs` | removed @6.15.1 | deduped into the hoisted `qs@6.15.2` |

That is the complete list. `logs/tree-diff.log` is the full path-keyed before/after
comparison: 14 packages moved, 2 added, 2 removed, package count unchanged at 654,
`lockfileVersion` unchanged at 3, and all 654 entries keep their `integrity` and
`resolved` fields.

### Why `express` had to move for the `qs` fix to be complete

`express@4.22.1` declares `qs@~6.14.0`, which capped its private copy at 6.14.2 — inside
the vulnerable range for GHSA-q8mj-m7cp-5q26 (`qs` 6.11.1–6.15.1) and unreachable by a
`qs` bump alone. `express@4.22.2` relaxes that to `qs@~6.15.1` (and
`body-parser@~1.20.5`), so both private `qs` copies now resolve to the hoisted 6.15.2 and
disappear from the tree. This is why Dependabot grouped them in #5, and both halves of
that PR are needed.

`express@5.2.1` nested under `@modelcontextprotocol/sdk` is deliberately left where it
is. #5's *declared* target is the 4.x copy (4.22.1 → 4.22.2); its branch *head*
additionally hoists express to 5.2.1 and deletes the nested copy, which this PR does not
take. The 5.2.1 copy was itself exposed to GHSA-q8mj-m7cp-5q26 through the shared hoisted
`qs`, and is fixed by the `qs` 6.15.2 bump.

## Verification

Run locally on this branch, with a `master` baseline for every step. Logs in `logs/`;
exit codes in `logs/status.tsv`; `logs/README.txt` maps each step to its log.

**Root project** (`.github/workflows/ci.yml` runs exactly these, on node 22.x and 24.x):

| Step | master | this branch | Log |
|---|---|---|---|
| `npm ci` | ✅ | ✅ | `base-root-install.log` / `root-install.log` |
| `npm run typecheck` | ✅ | ✅ | `base-root-typecheck.log` / `root-typecheck.log` |
| `npm run build` | ✅ | ✅ | `base-root-build.log` / `root-build.log` |
| `npm test` | ✅ 88 pass, 0 fail | ✅ 88 pass, 0 fail | `base-root-test.log` / `root-test.log` |

**Example project** (`examples/mastra-support-bot` — where the change actually is):

| Step | master | this branch | Log |
|---|---|---|---|
| `npm ci` (lock resolves) | ✅ | ✅ | `base-example-install.log` / `install.log` |
| `npm ls --all` (tree coherent) | ✅ no invalid/missing | ✅ no invalid/missing | `base-example-ls.log` / `example-ls.log` |
| `npm run build` (`mastra build`) | ✅ | ✅ | `base-example-build.log` / `build.log` |
| tests | n/a | n/a | no test script in `examples/mastra-support-bot/package.json` |
| lint | n/a | n/a | no lint script or lint config anywhere in the repo |

`npm ls --all` is included because this example declares three dependencies as `latest`
and has optional peers; `npm ci` alone will happily install an incoherent tree.

**On the build evidence** (`base-build-artifacts.log` / `build-artifacts.log`):
`mastra build` emits `.mastra/output`, then runs its *own* lockfile-free `npm install`
in there, so the bundled `node_modules` resolves from the registry and does not mirror
this lockfile — the ±2 files / −4,889 B between the two runs is that resolution's noise,
not a consequence of this change. What the comparison does establish is that the build
is real and equivalent: every emitted `.mjs` entrypoint is byte-identical in size
(`index.mjs` 1,796,876 B, `dist-CB67HEFG.mjs` 2,734,074 B, and so on), and
`.mastra/output/package.json` picks up `"hono": "4.13.1"` where master emitted
`"hono": "4.12.15"` — which is what accounts for the 383 → 382 B change in that file and
confirms the new lockfile was the input.

## Security impact

Open Dependabot alerts on master: 43, all anchored to
`examples/mastra-support-bot/package-lock.json` (`logs/alerts-open-base.tsv`; the root
lockfile has 5 entries and contains none of these packages).

This PR closes **42 of 43**:

- from the 7 PRs' declared targets (36): `hono` (21), `fast-uri` (5), `ip-address` (3),
  `ws` (2), `shell-quote` (2), `body-parser` (2), `qs` (1);
- from the extras folded in above (6): `js-yaml` (3), `brace-expansion` (2),
  `@hono/node-server` (1).

Every alert's `first_patched_version` is at or below the version installed here, so none
is a partial fix. The highest patch level required per package: `hono` 4.12.34 (→
4.13.1), `fast-uri` 3.1.5 (→ 3.1.5), `ip-address` 10.3.1 (→ 10.4.0), `ws` 8.21.0 (→
8.21.1), `shell-quote` 1.9.0 (→ 1.10.0), `body-parser` 1.20.6 / 2.3.0 (→ both), `qs`
6.15.2 (→ 6.15.2), `js-yaml` 3.15.1 (→ 3.15.1), `brace-expansion` 1.1.16 / 2.1.2 (→
1.1.18 / 2.1.4), `@hono/node-server` 1.19.15 (→ 1.19.17).

`npm audit` in the example goes from **13 vulnerabilities (3 low, 3 moderate, 6 high, 1
critical)** to **2 (2 low)** — `base-example-audit.log` vs `audit.log`. The lockfile was
not deleted or regenerated from scratch, so no manifest-anchored alert is reopened.

## Left open

- **1 alert**, on `@ai-sdk/provider-utils` (low, GHSA-866g-f22w-33x8). Its
  `first_patched_version` is `none`, and it has no Dependabot PR. `npm audit` does offer
  `npm audit fix --force` for it, but that resolves to `@mastra/core@1.63.2` — a major
  jump from the installed 1.45.0, outside the declared range, and outside this PR's
  scope.

All 7 discovered Dependabot PRs are folded in; no follow-up branch was needed.

## Known and accepted

- **CI does not exercise this change.** `.github/workflows/ci.yml` runs `npm ci`,
  `npm run typecheck`, `npm run build` and `npm test` at the repo root only. The root
  `package.json` declares no `workspaces`, and no workflow enters `examples/`, so a green
  CI run here proves nothing about this lockfile. The example-project rows above are the
  only evidence that it installs and builds, and they were produced locally on node
  22.23.2 / npm 12.0.2 (inside the CI matrix's 22.x leg). Pre-existing — the 7 Dependabot
  PRs being consolidated have the same blind spot.
- **The two branch heads carry further incidental moves that this PR declines.** #20's
  head differs from master in 7 package paths (its 2 declared bumps plus `qs` 6.15.3 and
  `side-channel` 1.1.1); #5's head, because of the conflict merge described above,
  differs in 269 — including `ws` 8.21.3, `express-rate-limit` 8.6.2, `@a2a-js/sdk`
  0.3.14, `@ai-sdk/provider-utils-v5` 3.0.30 and `-v6` 4.0.40, and the express 4 → 5
  hoist. None of these is required by an open advisory: `qs`'s first patched version is
  6.15.2 and `ws`'s is 8.21.0 (both met here), `@ai-sdk/provider-utils` has no patched
  release at any version, and `side-channel`, `express-rate-limit` and `@a2a-js/sdk` have
  no advisory at all. `logs/pr5-head-comparison.tsv` is the full three-way
  master / this-PR / #5-head table.
- **Newer in-range versions exist** for several of the bumped packages (`hono` 4.13.5,
  `qs` 6.16.0, `ws` 8.21.3, `ip-address` 10.7.0). No open advisory requires them, so the
  declared targets are what is installed.
- **`examples/mastra-support-bot` pins `@mastra/core`, `@mastra/libsql` and `mastra` to
  `latest`**, which makes any `npm install` in that directory non-reproducible. This is
  what turned #5's conflict merge into a ~230-package re-resolution. Pre-existing, and
  deliberately not touched here.
- The two duplicated nested `content-type` copies are npm's own resolution given
  `express` 4.x's `content-type@~1.0.4` pin, not a choice made here.
