### PR TITLE
feat: bundle skills with CLI and add install-skills command (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ Or use without installing:
 npx @nearform/tracebound <command>
 ```
 
+After installing, run this inside the project that contains your agent to copy
+the bundled skills (`analyze-traces`, `create-adapter`, `research-failure-mode`,
+`implement-failure-mode`) into that project's skills directory:
+
+```bash
+tracebound install-skills
+```
+
+By default, the command writes to `.claude/skills/tracebound/`. It is idempotent
+— re-running it reports already-installed skills as up-to-date and never
+overwrites a skill you have edited locally unless you pass `--force`. The CLI
+also runs `install-skills` from its `postinstall` hook as a best-effort default
+when your `cwd` at install time is the target project.
+
 ---
 
 ## Quick start
@@ -156,6 +170,7 @@ Commands:
   status               Print catalogue health for one agent.
   trace get <id>       Find a trace by id within one agent.
   fm get <id>          Print a failure mode by id within one agent.
+  install-skills       Copy bundled skills into the local project's skills directory.
 
 Global options:
   -h, --help           Show this help.
@@ -258,6 +273,27 @@ Options:
 Exit codes:
   0   found
   1   not found
+  2   could not run
+```
+
+### `tracebound install-skills`
+
+Copies every skill bundled with the CLI into the local project's skills
+directory. By default the target is `.claude/skills/tracebound/`. Skills that
+already exist locally with the same content are reported as up-to-date; skills
+you have edited locally are NOT overwritten unless `--force` is passed. When
+the CLI is installed in environments that disable `postinstall` (or when you
+upgrade), re-run this command to refresh the local copy.
+
+```
+Options:
+  -C, --cwd <path>     Directory to install skills into (default: cwd)
+  -t, --target <dir>   Subdirectory under --cwd (default: .claude/skills/tracebound)
+  -f, --force          Overwrite locally-modified skills
+      --dry-run        Print what would change, do not write
+
+Exit codes:
+  0   success (installed, up-to-date, or self-install skipped)
   2   could not run
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@nearform/tracebound",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build": "tsc -p tsconfig.build.json && node scripts/postbuild.js",
     "clean": "rm -rf dist",
     "install-skills": "node ./dist/cli.js install-skills --cwd .",
-    "postinstall": "node ./dist/cli.js install-skills --cwd . || exit 0",
+    "postinstall": "node ./dist/cli.js install-skills --cwd \"${INIT_CWD:-.}\" || exit 0",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm test",
     "test": "node --test src/__tests__/*.test.ts",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist",
+    "scripts/postinstall-install-skills.js",
     "skills",
     "templates",
     "README.md"
@@ -41,8 +42,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node scripts/postbuild.js",
     "clean": "rm -rf dist",
-    "install-skills": "node ./dist/cli.js install-skills --cwd .",
-    "postinstall": "node ./dist/cli.js install-skills --cwd \"${INIT_CWD:-.}\" || exit 0",
+    "postinstall": "node scripts/postinstall-install-skills.js || exit 0",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm test",
     "test": "node --test src/__tests__/*.test.ts",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist",
+    "skills",
     "templates",
     "README.md"
   ],
@@ -40,6 +41,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node scripts/postbuild.js",
     "clean": "rm -rf dist",
+    "install-skills": "node ./dist/cli.js install-skills --cwd .",
+    "postinstall": "node ./dist/cli.js install-skills --cwd . || exit 0",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm test",
     "test": "node --test src/__tests__/*.test.ts",

--- a/scripts/postinstall-install-skills.js
+++ b/scripts/postinstall-install-skills.js
@@ -12,6 +12,12 @@ const result = spawnSync(
   { stdio: "inherit" },
 );
 
+if (result.error) {
+  process.stderr.write(
+    `install-skills failed to start: ${result.error.message}\n`,
+  );
+}
+
 if (result.signal !== null) {
   process.stderr.write(
     `install-skills child terminated by signal ${result.signal}\n`,

--- a/scripts/postinstall-install-skills.js
+++ b/scripts/postinstall-install-skills.js
@@ -1,0 +1,15 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(here, "..", "dist", "cli.js");
+const cwd = process.env.INIT_CWD ?? ".";
+
+const result = spawnSync(
+  process.execPath,
+  [cliPath, "install-skills", "--cwd", cwd],
+  { stdio: "inherit" },
+);
+
+process.exit(result.status ?? 0);

--- a/scripts/postinstall-install-skills.js
+++ b/scripts/postinstall-install-skills.js
@@ -12,4 +12,10 @@ const result = spawnSync(
   { stdio: "inherit" },
 );
 
-process.exit(result.status ?? 0);
+if (result.signal !== null) {
+  process.stderr.write(
+    `install-skills child terminated by signal ${result.signal}\n`,
+  );
+}
+
+process.exit(result.status ?? 1);

--- a/src/__tests__/install-skills.test.ts
+++ b/src/__tests__/install-skills.test.ts
@@ -1,0 +1,195 @@
+import test from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  bundledSkillsDir,
+  runInstallSkills,
+  DEFAULT_TARGET,
+} from "../commands/install-skills.ts";
+
+async function makeTmpDir(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), "tracebound-install-skills-"));
+}
+
+async function listSkillNames(root: string): Promise<string[]> {
+  const { readdir } = await import("node:fs/promises");
+  const entries = await readdir(root, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+}
+
+test("bundledSkillsDir resolves to the repo's skills/ directory", async () => {
+  const dir = bundledSkillsDir();
+  const s = await stat(dir);
+  assert.equal(s.isDirectory(), true);
+  const names = await listSkillNames(dir);
+  assert.ok(names.includes("analyze-traces"));
+  assert.ok(names.includes("create-adapter"));
+  assert.ok(names.includes("research-failure-mode"));
+  assert.ok(names.includes("implement-failure-mode"));
+});
+
+test("runInstallSkills copies every bundled skill into the default target on a clean directory", async (t) => {
+  const cwd = await makeTmpDir();
+  t.after(() => rm(cwd, { recursive: true, force: true }));
+
+  const bundled = await listSkillNames(bundledSkillsDir());
+  const result = await runInstallSkills({ cwd });
+
+  assert.equal(result.selfInstallSkipped, false);
+  assert.equal(result.dryRun, false);
+  assert.equal(result.targetDir, join(cwd, DEFAULT_TARGET));
+  assert.deepEqual(result.installed, bundled);
+  assert.deepEqual(result.upToDate, []);
+  assert.deepEqual(result.skipped, []);
+
+  for (const skill of bundled) {
+    const targetPath = join(result.targetDir, skill, "SKILL.md");
+    const s = await stat(targetPath);
+    assert.equal(s.isFile(), true);
+  }
+});
+
+test("runInstallSkills is idempotent: a second run reports every skill as up-to-date", async (t) => {
+  const cwd = await makeTmpDir();
+  t.after(() => rm(cwd, { recursive: true, force: true }));
+
+  const first = await runInstallSkills({ cwd });
+  assert.ok(first.installed.length > 0);
+
+  const second = await runInstallSkills({ cwd });
+  assert.deepEqual(second.installed, []);
+  assert.deepEqual(second.upToDate.sort(), first.installed.slice().sort());
+  assert.deepEqual(second.skipped, []);
+});
+
+test("runInstallSkills leaves user-edited skills untouched by default", async (t) => {
+  const cwd = await makeTmpDir();
+  t.after(() => rm(cwd, { recursive: true, force: true }));
+
+  const first = await runInstallSkills({ cwd });
+  const bundled = first.installed.slice().sort();
+
+  const skill = "analyze-traces";
+  const targetPath = join(cwd, DEFAULT_TARGET, skill, "SKILL.md");
+  const userContent = "# user-edited\n";
+  await writeFile(targetPath, userContent, "utf8");
+
+  const result = await runInstallSkills({ cwd });
+  assert.deepEqual(result.installed, []);
+  assert.deepEqual(
+    result.upToDate.slice().sort(),
+    bundled.filter((s) => s !== skill),
+  );
+  assert.deepEqual(result.skipped, [skill]);
+
+  const after = await readFile(targetPath, "utf8");
+  assert.equal(after, userContent);
+});
+
+test("runInstallSkills --force overwrites user-edited skills", async (t) => {
+  const cwd = await makeTmpDir();
+  t.after(() => rm(cwd, { recursive: true, force: true }));
+
+  await runInstallSkills({ cwd });
+
+  const skill = "analyze-traces";
+  const targetPath = join(cwd, DEFAULT_TARGET, skill, "SKILL.md");
+  const userContent = "# user-edited\n";
+  await writeFile(targetPath, userContent, "utf8");
+
+  const result = await runInstallSkills({ cwd, force: true });
+  assert.ok(result.installed.includes(skill));
+  assert.equal(result.skipped.length, 0);
+
+  const bundledRaw = await readFile(
+    join(bundledSkillsDir(), skill, "SKILL.md"),
+    "utf8",
+  );
+  const after = await readFile(targetPath, "utf8");
+  assert.equal(after, bundledRaw);
+});
+
+test("runInstallSkills --dry-run writes nothing", async (t) => {
+  const cwd = await makeTmpDir();
+  t.after(() => rm(cwd, { recursive: true, force: true }));
+
+  const bundled = await listSkillNames(bundledSkillsDir());
+  const result = await runInstallSkills({ cwd, dryRun: true });
+
+  assert.equal(result.dryRun, true);
+  assert.deepEqual(result.installed, bundled);
+  assert.equal(result.upToDate.length, 0);
+
+  await assert.rejects(
+    () => stat(join(result.targetDir, "analyze-traces", "SKILL.md")),
+    /ENOENT/,
+  );
+});
+
+test("runInstallSkills honours --target for a custom install location", async (t) => {
+  const cwd = await makeTmpDir();
+  t.after(() => rm(cwd, { recursive: true, force: true }));
+
+  const result = await runInstallSkills({
+    cwd,
+    target: "my/custom/skills",
+  });
+
+  assert.equal(result.targetDir, join(cwd, "my", "custom", "skills"));
+  const s = await stat(join(result.targetDir, "analyze-traces", "SKILL.md"));
+  assert.equal(s.isFile(), true);
+});
+
+test("runInstallSkills skips silently when --cwd is the tracebound package itself", async (t) => {
+  const cwd = await makeTmpDir();
+  t.after(() => rm(cwd, { recursive: true, force: true }));
+
+  await writeFile(
+    join(cwd, "package.json"),
+    `${JSON.stringify({ name: "@nearform/tracebound" }, null, 2)}\n`,
+    "utf8",
+  );
+
+  const result = await runInstallSkills({ cwd });
+  assert.equal(result.selfInstallSkipped, true);
+  assert.equal(result.installed.length, 0);
+  await assert.rejects(
+    () => stat(join(cwd, ".claude")),
+    /ENOENT/,
+  );
+});
+
+test("runInstallSkills rejects --cwd that does not exist", async () => {
+  const missing = join(
+    tmpdir(),
+    `tracebound-missing-${process.pid}-${Date.now()}`,
+  );
+  await assert.rejects(
+    () => runInstallSkills({ cwd: missing }),
+    /does not exist/,
+  );
+});
+
+test("runInstallSkills rejects --cwd that is a file, not a directory", async (t) => {
+  const cwd = await makeTmpDir();
+  t.after(() => rm(cwd, { recursive: true, force: true }));
+  const filePath = join(cwd, "not-a-dir");
+  await writeFile(filePath, "x", "utf8");
+
+  await assert.rejects(
+    () => runInstallSkills({ cwd: filePath }),
+    /not a directory/,
+  );
+});

--- a/src/__tests__/install-skills.test.ts
+++ b/src/__tests__/install-skills.test.ts
@@ -197,3 +197,21 @@ test("runInstallSkills rejects --cwd whose package.json is malformed JSON", asyn
     /malformed JSON in .*package\.json/,
   );
 });
+
+test("runInstallSkills rejects --target that resolves outside --cwd", async (t: TestContext) => {
+  const cwd = await makeTmpDir(t);
+  await t.assert.rejects(
+    () => runInstallSkills({ cwd, target: "../escape" }),
+    /--target must resolve inside --cwd/,
+  );
+  await t.assert.rejects(
+    () => runInstallSkills({ cwd, target: "/etc" }),
+    /--target must resolve inside --cwd/,
+  );
+});
+
+test("runInstallSkills accepts --target equal to --cwd", async (t: TestContext) => {
+  const cwd = await makeTmpDir(t);
+  const result = await runInstallSkills({ cwd, target: "." });
+  t.assert.strictEqual(result.targetDir, cwd);
+});

--- a/src/__tests__/install-skills.test.ts
+++ b/src/__tests__/install-skills.test.ts
@@ -233,3 +233,17 @@ test("runInstallSkills resolves --cwd symlinks before checking target containmen
   const result = await runInstallSkills({ cwd: linkPath });
   t.assert.ok(result.targetDir.startsWith(realDir));
 });
+
+test("runInstallSkills rejects an intermediate --target symlink that escapes --cwd", async (t: TestContext) => {
+  const outside = await makeTmpDir(t);
+  const project = await makeTmpDir(t);
+  // Symlink inside the project that points outside it. The default target
+  // path is .claude/skills/tracebound; we make .claude a symlink to `outside`
+  // so the realpath of the resolved target lands outside project.
+  await symlink(outside, join(project, ".claude"));
+
+  await t.assert.rejects(
+    () => runInstallSkills({ cwd: project }),
+    /--target resolved through a symlink that escapes --cwd/,
+  );
+});

--- a/src/__tests__/install-skills.test.ts
+++ b/src/__tests__/install-skills.test.ts
@@ -1,7 +1,7 @@
-import test from "node:test";
-import { strict as assert } from "node:assert";
+import test, { type TestContext } from "node:test";
 import {
   mkdtemp,
+  readdir,
   readFile,
   rm,
   stat,
@@ -16,12 +16,14 @@ import {
   DEFAULT_TARGET,
 } from "../commands/install-skills.ts";
 
-async function makeTmpDir(): Promise<string> {
-  return await mkdtemp(join(tmpdir(), "tracebound-install-skills-"));
+function makeTmpDir(t: TestContext): Promise<string> {
+  return mkdtemp(join(tmpdir(), "tracebound-install-skills-")).then((dir) => {
+    t.after(() => rm(dir, { recursive: true, force: true }));
+    return dir;
+  });
 }
 
 async function listSkillNames(root: string): Promise<string[]> {
-  const { readdir } = await import("node:fs/promises");
   const entries = await readdir(root, { withFileTypes: true });
   return entries
     .filter((e) => e.isDirectory())
@@ -29,54 +31,51 @@ async function listSkillNames(root: string): Promise<string[]> {
     .sort();
 }
 
-test("bundledSkillsDir resolves to the repo's skills/ directory", async () => {
+test("bundledSkillsDir resolves to the repo's skills/ directory", async (t: TestContext) => {
   const dir = bundledSkillsDir();
   const s = await stat(dir);
-  assert.equal(s.isDirectory(), true);
+  t.assert.strictEqual(s.isDirectory(), true);
   const names = await listSkillNames(dir);
-  assert.ok(names.includes("analyze-traces"));
-  assert.ok(names.includes("create-adapter"));
-  assert.ok(names.includes("research-failure-mode"));
-  assert.ok(names.includes("implement-failure-mode"));
+  t.assert.ok(names.includes("analyze-traces"));
+  t.assert.ok(names.includes("create-adapter"));
+  t.assert.ok(names.includes("research-failure-mode"));
+  t.assert.ok(names.includes("implement-failure-mode"));
 });
 
-test("runInstallSkills copies every bundled skill into the default target on a clean directory", async (t) => {
-  const cwd = await makeTmpDir();
-  t.after(() => rm(cwd, { recursive: true, force: true }));
+test("runInstallSkills copies every bundled skill into the default target on a clean directory", async (t: TestContext) => {
+  const cwd = await makeTmpDir(t);
 
   const bundled = await listSkillNames(bundledSkillsDir());
   const result = await runInstallSkills({ cwd });
 
-  assert.equal(result.selfInstallSkipped, false);
-  assert.equal(result.dryRun, false);
-  assert.equal(result.targetDir, join(cwd, DEFAULT_TARGET));
-  assert.deepEqual(result.installed, bundled);
-  assert.deepEqual(result.upToDate, []);
-  assert.deepEqual(result.skipped, []);
+  t.assert.strictEqual(result.selfInstallSkipped, false);
+  t.assert.strictEqual(result.dryRun, false);
+  t.assert.strictEqual(result.targetDir, join(cwd, DEFAULT_TARGET));
+  t.assert.deepStrictEqual(result.installed, bundled);
+  t.assert.deepStrictEqual(result.upToDate, []);
+  t.assert.deepStrictEqual(result.skipped, []);
 
   for (const skill of bundled) {
     const targetPath = join(result.targetDir, skill, "SKILL.md");
     const s = await stat(targetPath);
-    assert.equal(s.isFile(), true);
+    t.assert.strictEqual(s.isFile(), true);
   }
 });
 
-test("runInstallSkills is idempotent: a second run reports every skill as up-to-date", async (t) => {
-  const cwd = await makeTmpDir();
-  t.after(() => rm(cwd, { recursive: true, force: true }));
+test("runInstallSkills is idempotent: a second run reports every skill as up-to-date", async (t: TestContext) => {
+  const cwd = await makeTmpDir(t);
 
   const first = await runInstallSkills({ cwd });
-  assert.ok(first.installed.length > 0);
+  t.assert.ok(first.installed.length > 0);
 
   const second = await runInstallSkills({ cwd });
-  assert.deepEqual(second.installed, []);
-  assert.deepEqual(second.upToDate.sort(), first.installed.slice().sort());
-  assert.deepEqual(second.skipped, []);
+  t.assert.deepStrictEqual(second.installed, []);
+  t.assert.deepStrictEqual(second.upToDate.sort(), first.installed.slice().sort());
+  t.assert.deepStrictEqual(second.skipped, []);
 });
 
-test("runInstallSkills leaves user-edited skills untouched by default", async (t) => {
-  const cwd = await makeTmpDir();
-  t.after(() => rm(cwd, { recursive: true, force: true }));
+test("runInstallSkills leaves user-edited skills untouched by default", async (t: TestContext) => {
+  const cwd = await makeTmpDir(t);
 
   const first = await runInstallSkills({ cwd });
   const bundled = first.installed.slice().sort();
@@ -87,20 +86,19 @@ test("runInstallSkills leaves user-edited skills untouched by default", async (t
   await writeFile(targetPath, userContent, "utf8");
 
   const result = await runInstallSkills({ cwd });
-  assert.deepEqual(result.installed, []);
-  assert.deepEqual(
+  t.assert.deepStrictEqual(result.installed, []);
+  t.assert.deepStrictEqual(
     result.upToDate.slice().sort(),
     bundled.filter((s) => s !== skill),
   );
-  assert.deepEqual(result.skipped, [skill]);
+  t.assert.deepStrictEqual(result.skipped, [skill]);
 
   const after = await readFile(targetPath, "utf8");
-  assert.equal(after, userContent);
+  t.assert.strictEqual(after, userContent);
 });
 
-test("runInstallSkills --force overwrites user-edited skills", async (t) => {
-  const cwd = await makeTmpDir();
-  t.after(() => rm(cwd, { recursive: true, force: true }));
+test("runInstallSkills --force overwrites user-edited skills", async (t: TestContext) => {
+  const cwd = await makeTmpDir(t);
 
   await runInstallSkills({ cwd });
 
@@ -110,51 +108,48 @@ test("runInstallSkills --force overwrites user-edited skills", async (t) => {
   await writeFile(targetPath, userContent, "utf8");
 
   const result = await runInstallSkills({ cwd, force: true });
-  assert.ok(result.installed.includes(skill));
-  assert.equal(result.skipped.length, 0);
+  t.assert.ok(result.installed.includes(skill));
+  t.assert.strictEqual(result.skipped.length, 0);
 
   const bundledRaw = await readFile(
     join(bundledSkillsDir(), skill, "SKILL.md"),
     "utf8",
   );
   const after = await readFile(targetPath, "utf8");
-  assert.equal(after, bundledRaw);
+  t.assert.strictEqual(after, bundledRaw);
 });
 
-test("runInstallSkills --dry-run writes nothing", async (t) => {
-  const cwd = await makeTmpDir();
-  t.after(() => rm(cwd, { recursive: true, force: true }));
+test("runInstallSkills --dry-run writes nothing", async (t: TestContext) => {
+  const cwd = await makeTmpDir(t);
 
   const bundled = await listSkillNames(bundledSkillsDir());
   const result = await runInstallSkills({ cwd, dryRun: true });
 
-  assert.equal(result.dryRun, true);
-  assert.deepEqual(result.installed, bundled);
-  assert.equal(result.upToDate.length, 0);
+  t.assert.strictEqual(result.dryRun, true);
+  t.assert.deepStrictEqual(result.installed, bundled);
+  t.assert.strictEqual(result.upToDate.length, 0);
 
-  await assert.rejects(
+  await t.assert.rejects(
     () => stat(join(result.targetDir, "analyze-traces", "SKILL.md")),
     /ENOENT/,
   );
 });
 
-test("runInstallSkills honours --target for a custom install location", async (t) => {
-  const cwd = await makeTmpDir();
-  t.after(() => rm(cwd, { recursive: true, force: true }));
+test("runInstallSkills honours --target for a custom install location", async (t: TestContext) => {
+  const cwd = await makeTmpDir(t);
 
   const result = await runInstallSkills({
     cwd,
     target: "my/custom/skills",
   });
 
-  assert.equal(result.targetDir, join(cwd, "my", "custom", "skills"));
+  t.assert.strictEqual(result.targetDir, join(cwd, "my", "custom", "skills"));
   const s = await stat(join(result.targetDir, "analyze-traces", "SKILL.md"));
-  assert.equal(s.isFile(), true);
+  t.assert.strictEqual(s.isFile(), true);
 });
 
-test("runInstallSkills skips silently when --cwd is the tracebound package itself", async (t) => {
-  const cwd = await makeTmpDir();
-  t.after(() => rm(cwd, { recursive: true, force: true }));
+test("runInstallSkills skips silently when --cwd is the tracebound package itself", async (t: TestContext) => {
+  const cwd = await makeTmpDir(t);
 
   await writeFile(
     join(cwd, "package.json"),
@@ -163,44 +158,42 @@ test("runInstallSkills skips silently when --cwd is the tracebound package itsel
   );
 
   const result = await runInstallSkills({ cwd });
-  assert.equal(result.selfInstallSkipped, true);
-  assert.equal(result.installed.length, 0);
-  await assert.rejects(
+  t.assert.strictEqual(result.selfInstallSkipped, true);
+  t.assert.strictEqual(result.installed.length, 0);
+  await t.assert.rejects(
     () => stat(join(cwd, ".claude")),
     /ENOENT/,
   );
 });
 
-test("runInstallSkills rejects --cwd that does not exist", async () => {
+test("runInstallSkills rejects --cwd that does not exist", async (t: TestContext) => {
   const missing = join(
     tmpdir(),
     `tracebound-missing-${process.pid}-${Date.now()}`,
   );
-  await assert.rejects(
+  await t.assert.rejects(
     () => runInstallSkills({ cwd: missing }),
     /does not exist/,
   );
 });
 
-test("runInstallSkills rejects --cwd that is a file, not a directory", async (t) => {
-  const cwd = await makeTmpDir();
-  t.after(() => rm(cwd, { recursive: true, force: true }));
+test("runInstallSkills rejects --cwd that is a file, not a directory", async (t: TestContext) => {
+  const cwd = await makeTmpDir(t);
   const filePath = join(cwd, "not-a-dir");
   await writeFile(filePath, "x", "utf8");
 
-  await assert.rejects(
+  await t.assert.rejects(
     () => runInstallSkills({ cwd: filePath }),
     /not a directory/,
   );
 });
 
-test("runInstallSkills rejects --cwd whose package.json is malformed JSON", async (t) => {
-  const cwd = await makeTmpDir();
-  t.after(() => rm(cwd, { recursive: true, force: true }));
+test("runInstallSkills rejects --cwd whose package.json is malformed JSON", async (t: TestContext) => {
+  const cwd = await makeTmpDir(t);
 
   await writeFile(join(cwd, "package.json"), "{ not valid json", "utf8");
 
-  await assert.rejects(
+  await t.assert.rejects(
     () => runInstallSkills({ cwd }),
     /malformed JSON in .*package\.json/,
   );

--- a/src/__tests__/install-skills.test.ts
+++ b/src/__tests__/install-skills.test.ts
@@ -16,11 +16,10 @@ import {
   DEFAULT_TARGET,
 } from "../commands/install-skills.ts";
 
-function makeTmpDir(t: TestContext): Promise<string> {
-  return mkdtemp(join(tmpdir(), "tracebound-install-skills-")).then((dir) => {
-    t.after(() => rm(dir, { recursive: true, force: true }));
-    return dir;
-  });
+async function makeTmpDir(t: TestContext): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tracebound-install-skills-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  return dir;
 }
 
 async function listSkillNames(root: string): Promise<string[]> {

--- a/src/__tests__/install-skills.test.ts
+++ b/src/__tests__/install-skills.test.ts
@@ -193,3 +193,15 @@ test("runInstallSkills rejects --cwd that is a file, not a directory", async (t)
     /not a directory/,
   );
 });
+
+test("runInstallSkills rejects --cwd whose package.json is malformed JSON", async (t) => {
+  const cwd = await makeTmpDir();
+  t.after(() => rm(cwd, { recursive: true, force: true }));
+
+  await writeFile(join(cwd, "package.json"), "{ not valid json", "utf8");
+
+  await assert.rejects(
+    () => runInstallSkills({ cwd }),
+    /malformed JSON in .*package\.json/,
+  );
+});

--- a/src/__tests__/install-skills.test.ts
+++ b/src/__tests__/install-skills.test.ts
@@ -5,6 +5,7 @@ import {
   readFile,
   rm,
   stat,
+  symlink,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -213,5 +214,22 @@ test("runInstallSkills rejects --target that resolves outside --cwd", async (t: 
 test("runInstallSkills accepts --target equal to --cwd", async (t: TestContext) => {
   const cwd = await makeTmpDir(t);
   const result = await runInstallSkills({ cwd, target: "." });
-  t.assert.strictEqual(result.targetDir, cwd);
+  // targetDir is resolved against the realpath of cwd to prevent symlink-bypass.
+  // On filesystems where the tmp path contains symlinks (e.g. macOS /tmp -> /private/tmp),
+  // the realpath differs from the original cwd.
+  const { realpath } = await import("node:fs/promises");
+  const cwdReal = await realpath(cwd);
+  t.assert.strictEqual(result.targetDir, cwdReal);
+});
+
+test("runInstallSkills resolves --cwd symlinks before checking target containment", async (t: TestContext) => {
+  const realDir = await makeTmpDir(t);
+  const linkParent = await makeTmpDir(t);
+  const linkPath = join(linkParent, "link");
+  await symlink(realDir, linkPath);
+
+  // --target that would be outside realDir if symlink resolution were skipped,
+  // but is inside it after realpath resolves the link.
+  const result = await runInstallSkills({ cwd: linkPath });
+  t.assert.ok(result.targetDir.startsWith(realDir));
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,10 @@ import {
   reportText,
   runValidate,
 } from "./commands/validate.ts";
+import {
+  reportText as installSkillsReportText,
+  runInstallSkills,
+} from "./commands/install-skills.ts";
 
 const USAGE = `tracebound — deterministic primitives for the Tracebound agent-improvement loop.
 
@@ -41,6 +45,7 @@ Commands:
   status               Print catalogue health + pending-trace counts for one agent.
   trace get <id>       Find a trace by id across one agent's traces/*.jsonl files.
   fm get <id>          Print a failure mode by id from one agent's failure_modes.json.
+  install-skills       Copy the bundled Tracebound skills into the local project's skills directory.
 
 Global options:
   -h, --help           Show this help.
@@ -174,6 +179,35 @@ Exit codes:
   0  status report printed
   2  could not run (missing/invalid --cwd, missing or unknown --agent, malformed
      failure_modes.json — run 'tracebound validate --agent <name>' for details)
+`;
+
+const INSTALL_SKILLS_USAGE = `tracebound install-skills — copy bundled skills into a project's skills directory.
+
+Usage:
+  tracebound install-skills [options]
+
+Copies every skill bundled with the CLI (analyze-traces, create-adapter,
+research-failure-mode, implement-failure-mode) into the local project's
+skills directory. By default, skills that already exist locally with the
+same content are left untouched, and skills that have been edited locally
+are NOT overwritten unless --force is passed.
+
+When --cwd is the @nearform/tracebound package itself (e.g. when invoked
+from a postinstall script inside the package), the command exits 0 without
+writing anything.
+
+Options:
+  -C, --cwd <path>     Directory to install skills into (default: process.cwd()).
+                       Must exist and be a directory.
+  -t, --target <dir>   Subdirectory under --cwd to install skills into.
+                       Default: .claude/skills/tracebound
+  -f, --force          Overwrite skills whose local copy differs from the bundled copy.
+      --dry-run        Print what would change, do not write.
+  -h, --help           Show this help.
+
+Exit codes:
+  0  success (skills installed, already up-to-date, or self-install skipped)
+  2  could not run (missing/invalid --cwd, bundled skills missing, IO error)
 `;
 
 async function readVersion(): Promise<string> {
@@ -467,6 +501,43 @@ async function runAgentsCommand(argv: string[]): Promise<void> {
   process.stdout.write(output);
 }
 
+async function runInstallSkillsCommand(argv: string[]): Promise<void> {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: argv,
+      options: {
+        cwd: { type: "string", short: "C" },
+        target: { type: "string", short: "t" },
+        force: { type: "boolean", short: "f", default: false },
+        "dry-run": { type: "boolean", default: false },
+        help: { type: "boolean", short: "h", default: false },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+  } catch (err) {
+    fail((err as Error).message, 2);
+  }
+
+  if (parsed.values.help) {
+    process.stdout.write(INSTALL_SKILLS_USAGE);
+    return;
+  }
+
+  try {
+    const result = await runInstallSkills({
+      cwd: parsed.values.cwd,
+      target: parsed.values.target,
+      force: parsed.values.force,
+      dryRun: parsed.values["dry-run"],
+    });
+    process.stdout.write(installSkillsReportText(result));
+  } catch (err) {
+    fail(err instanceof Error ? err.message : String(err), 2);
+  }
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
@@ -513,6 +584,9 @@ async function main(): Promise<void> {
       fail(`unknown subcommand: fm ${sub ?? ""}\n\nRun 'tracebound fm get <id>' to look up a failure mode.`);
       return;
     }
+    case "install-skills":
+      await runInstallSkillsCommand(rest);
+      return;
     default:
       fail(`unknown command: ${command}\n\n${USAGE}`);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ import {
 import {
   reportText as installSkillsReportText,
   runInstallSkills,
+  DEFAULT_TARGET as INSTALL_SKILLS_DEFAULT_TARGET,
 } from "./commands/install-skills.ts";
 
 const USAGE = `tracebound — deterministic primitives for the Tracebound agent-improvement loop.
@@ -200,7 +201,7 @@ Options:
   -C, --cwd <path>     Directory to install skills into (default: process.cwd()).
                        Must exist and be a directory.
   -t, --target <dir>   Subdirectory under --cwd to install skills into.
-                       Default: .claude/skills/tracebound
+                       Default: ${INSTALL_SKILLS_DEFAULT_TARGET}
   -f, --force          Overwrite skills whose local copy differs from the bundled copy.
       --dry-run        Print what would change, do not write.
   -h, --help           Show this help.

--- a/src/commands/install-skills.ts
+++ b/src/commands/install-skills.ts
@@ -1,4 +1,11 @@
-import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  readdir,
+  readFile,
+  realpath,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { dirname, join, resolve, sep } from "node:path";
 import { styleText } from "node:util";
 
@@ -112,8 +119,9 @@ export async function runInstallSkills(
     );
   }
 
-  const targetDir = resolve(cwdAbsolute, options.target ?? DEFAULT_TARGET);
-  if (targetDir !== cwdAbsolute && !targetDir.startsWith(cwdAbsolute + sep)) {
+  const cwdReal = await realpath(cwdAbsolute);
+  const targetDir = resolve(cwdReal, options.target ?? DEFAULT_TARGET);
+  if (targetDir !== cwdReal && !targetDir.startsWith(cwdReal + sep)) {
     throw new Error(
       `--target must resolve inside --cwd: ${targetDir} is outside ${cwdAbsolute}`,
     );

--- a/src/commands/install-skills.ts
+++ b/src/commands/install-skills.ts
@@ -128,6 +128,12 @@ export async function runInstallSkills(
   }
   if (!dryRun) {
     await mkdir(targetDir, { recursive: true });
+    const targetReal = await realpath(targetDir);
+    if (targetReal !== cwdReal && !targetReal.startsWith(cwdReal + sep)) {
+      throw new Error(
+        `--target resolved through a symlink that escapes --cwd: ${targetDir} -> ${targetReal}`,
+      );
+    }
   }
 
   const result: InstallSkillsResult = {

--- a/src/commands/install-skills.ts
+++ b/src/commands/install-skills.ts
@@ -1,12 +1,6 @@
-import {
-  mkdir,
-  readdir,
-  readFile,
-  stat,
-  writeFile,
-} from "node:fs/promises";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 import { styleText } from "node:util";
 
 export interface InstallSkillsOptions {
@@ -41,33 +35,21 @@ export const DEFAULT_TARGET = ".claude/skills/tracebound";
  * running from `src/commands/` (source/tests) or `dist/commands/` (built CLI).
  */
 export function bundledSkillsDir(): string {
-  const here = dirname(fileURLToPath(import.meta.url));
-  return resolve(here, "..", "..", "skills");
+  return resolve(import.meta.dirname, "..", "..", "skills");
 }
 
-async function pathExists(p: string): Promise<boolean> {
-  try {
-    await stat(p);
-    return true;
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
-    throw err;
-  }
-}
-
-async function listSkillNames(skillsRoot: string): Promise<string[]> {
-  const entries = await readdir(skillsRoot, { withFileTypes: true });
-  return entries
+function listSkillNames(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true })
     .filter((e) => e.isDirectory())
     .map((e) => e.name)
     .sort();
 }
 
-async function isOwnPackageDir(cwdAbsolute: string): Promise<boolean> {
-  const pkgPath = join(cwdAbsolute, "package.json");
+function isOwnPackageDir(cwdAbsolute: string): boolean {
   try {
-    const raw = await readFile(pkgPath, "utf8");
-    const pkg = JSON.parse(raw) as { name?: unknown };
+    const pkg = JSON.parse(
+      readFileSync(join(cwdAbsolute, "package.json"), "utf8"),
+    ) as { name?: unknown };
     return pkg.name === "@nearform/tracebound";
   } catch {
     return false;
@@ -77,47 +59,47 @@ async function isOwnPackageDir(cwdAbsolute: string): Promise<boolean> {
 export async function runInstallSkills(
   options: InstallSkillsOptions = {},
 ): Promise<InstallSkillsResult> {
-  const cwdInput = options.cwd ?? process.cwd();
-  const cwdAbsolute = resolve(cwdInput);
+  const cwdAbsolute = resolve(options.cwd ?? process.cwd());
 
-  const cwdInfo = await stat(cwdAbsolute).catch((err) => {
+  let cwdStat;
+  try {
+    cwdStat = statSync(cwdAbsolute);
+  } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       throw new Error(`--cwd path does not exist: ${cwdAbsolute}`);
     }
     throw err;
-  });
-  if (!cwdInfo.isDirectory()) {
+  }
+  if (!cwdStat.isDirectory()) {
     throw new Error(`--cwd path is not a directory: ${cwdAbsolute}`);
   }
 
-  if (await isOwnPackageDir(cwdAbsolute)) {
+  const dryRun = options.dryRun ?? false;
+
+  if (isOwnPackageDir(cwdAbsolute)) {
     return {
       cwdAbsolute,
       targetDir: "",
       installed: [],
       upToDate: [],
       skipped: [],
-      dryRun: options.dryRun ?? false,
+      dryRun,
       selfInstallSkipped: true,
     };
   }
 
-  const targetRelative = options.target ?? DEFAULT_TARGET;
-  const targetDir = resolve(cwdAbsolute, targetRelative);
-
   const bundledDir = bundledSkillsDir();
-  if (!(await pathExists(bundledDir))) {
+  if (!existsSync(bundledDir)) {
     throw new Error(
       `bundled skills directory not found: ${bundledDir}. This CLI install is missing the 'skills/' directory.`,
     );
   }
 
-  const dryRun = options.dryRun ?? false;
+  const targetDir = resolve(cwdAbsolute, options.target ?? DEFAULT_TARGET);
   if (!dryRun) {
     await mkdir(targetDir, { recursive: true });
   }
 
-  const skills = await listSkillNames(bundledDir);
   const result: InstallSkillsResult = {
     cwdAbsolute,
     targetDir,
@@ -128,17 +110,16 @@ export async function runInstallSkills(
     selfInstallSkipped: false,
   };
 
-  for (const skill of skills) {
+  for (const skill of listSkillNames(bundledDir)) {
     const sourcePath = join(bundledDir, skill, "SKILL.md");
     const targetPath = join(targetDir, skill, "SKILL.md");
 
-    if (!(await pathExists(sourcePath))) {
-      continue;
-    }
+    if (!existsSync(sourcePath)) continue;
 
-    const sourceContents = await readFile(sourcePath, "utf8");
+    const sourceContents = readFileSync(sourcePath, "utf8");
+    const targetExists = existsSync(targetPath);
 
-    if (!(await pathExists(targetPath))) {
+    if (!targetExists) {
       if (!dryRun) {
         await mkdir(dirname(targetPath), { recursive: true });
         await writeFile(targetPath, sourceContents, "utf8");
@@ -147,7 +128,7 @@ export async function runInstallSkills(
       continue;
     }
 
-    const targetContents = await readFile(targetPath, "utf8");
+    const targetContents = readFileSync(targetPath, "utf8");
     if (targetContents === sourceContents) {
       result.upToDate.push(skill);
       continue;
@@ -168,53 +149,40 @@ export async function runInstallSkills(
 }
 
 export function reportText(result: InstallSkillsResult): string {
-  const lines: string[] = [];
-
   if (result.selfInstallSkipped) {
-    lines.push(
-      `${styleText(
+    return (
+      styleText(
         "dim",
         `skipped: cwd is the @nearform/tracebound package itself (${result.cwdAbsolute})`,
-      )}`,
+      ) + "\n"
     );
-    return lines.join("\n") + "\n";
   }
 
-  if (result.installed.length > 0) {
-    for (const skill of result.installed) {
-      const verb = result.dryRun ? "would install" : "installed";
-      lines.push(
-        `${styleText("green", "✓")} ${verb}: ${join(result.targetDir, skill)}`,
-      );
-    }
-  }
+  const lines: string[] = [];
+  const verb = result.dryRun ? "would install" : "installed";
 
+  for (const skill of result.installed) {
+    lines.push(
+      `${styleText("green", "✓")} ${verb}: ${join(result.targetDir, skill)}`,
+    );
+  }
   if (result.upToDate.length > 0) {
     lines.push(
-      `${styleText("dim", `up-to-date: ${result.upToDate.join(", ")}`)}`,
+      styleText("dim", `up-to-date: ${result.upToDate.join(", ")}`),
     );
   }
-
-  if (result.skipped.length > 0) {
-    for (const skill of result.skipped) {
-      lines.push(
-        `${styleText(
-          "yellow",
-          "!",
-        )} skipped (modified locally, use --force to overwrite): ${join(
-          result.targetDir,
-          skill,
-        )}`,
-      );
-    }
+  for (const skill of result.skipped) {
+    lines.push(
+      `${styleText("yellow", "!")} skipped (modified locally, use --force to overwrite): ${join(result.targetDir, skill)}`,
+    );
   }
 
   lines.push("");
   lines.push(
-    `${styleText(
+    styleText(
       "dim",
-      `${result.installed.length} installed, ${result.upToDate.length} up-to-date, ${result.skipped.length} skipped`,
-    )} → ${result.targetDir}`,
+      `${result.installed.length} installed, ${result.upToDate.length} up-to-date, ${result.skipped.length} skipped → ${result.targetDir}`,
+    ),
   );
 
   return lines.join("\n") + "\n";

--- a/src/commands/install-skills.ts
+++ b/src/commands/install-skills.ts
@@ -11,29 +11,17 @@ export interface InstallSkillsOptions {
 }
 
 export interface InstallSkillsResult {
-  /** Absolute path to the resolved cwd. */
   cwdAbsolute: string;
-  /** Absolute path to the directory skills were copied into. */
   targetDir: string;
-  /** Skill names copied (or that would be copied in dry-run). */
   installed: string[];
-  /** Skill names that already match the bundled content. */
   upToDate: string[];
-  /** Skill names that exist locally with different content and were left untouched. */
   skipped: string[];
-  /** True when no write was performed because of --dry-run. */
   dryRun: boolean;
-  /** True when install was skipped because cwd is the tracebound package itself. */
   selfInstallSkipped: boolean;
 }
 
 export const DEFAULT_TARGET = ".claude/skills/tracebound";
 
-/**
- * Absolute path to the directory holding the bundled skills in the installed
- * package. Resolves `<package-root>/skills` regardless of whether this file is
- * running from `src/commands/` (source/tests) or `dist/commands/` (built CLI).
- */
 export function bundledSkillsDir(): string {
   return resolve(import.meta.dirname, "..", "..", "skills");
 }
@@ -46,14 +34,21 @@ function listSkillNames(root: string): string[] {
 }
 
 function isOwnPackageDir(cwdAbsolute: string): boolean {
+  const pkgPath = join(cwdAbsolute, "package.json");
+  let raw: string;
   try {
-    const pkg = JSON.parse(
-      readFileSync(join(cwdAbsolute, "package.json"), "utf8"),
-    ) as { name?: unknown };
-    return pkg.name === "@nearform/tracebound";
-  } catch {
-    return false;
+    raw = readFileSync(pkgPath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw new Error(`could not read ${pkgPath}`, { cause: err });
   }
+  let pkg: { name?: unknown };
+  try {
+    pkg = JSON.parse(raw) as { name?: unknown };
+  } catch (err) {
+    throw new Error(`malformed JSON in ${pkgPath}`, { cause: err });
+  }
+  return pkg.name === "@nearform/tracebound";
 }
 
 export async function runInstallSkills(
@@ -68,7 +63,9 @@ export async function runInstallSkills(
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       throw new Error(`--cwd path does not exist: ${cwdAbsolute}`);
     }
-    throw err;
+    throw new Error(`could not stat --cwd path: ${cwdAbsolute}`, {
+      cause: err,
+    });
   }
   if (!cwdStat.isDirectory()) {
     throw new Error(`--cwd path is not a directory: ${cwdAbsolute}`);

--- a/src/commands/install-skills.ts
+++ b/src/commands/install-skills.ts
@@ -1,5 +1,5 @@
 import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import { styleText } from "node:util";
 
 export interface InstallSkillsOptions {
@@ -113,6 +113,11 @@ export async function runInstallSkills(
   }
 
   const targetDir = resolve(cwdAbsolute, options.target ?? DEFAULT_TARGET);
+  if (targetDir !== cwdAbsolute && !targetDir.startsWith(cwdAbsolute + sep)) {
+    throw new Error(
+      `--target must resolve inside --cwd: ${targetDir} is outside ${cwdAbsolute}`,
+    );
+  }
   if (!dryRun) {
     await mkdir(targetDir, { recursive: true });
   }

--- a/src/commands/install-skills.ts
+++ b/src/commands/install-skills.ts
@@ -1,5 +1,4 @@
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { styleText } from "node:util";
 
@@ -26,18 +25,19 @@ export function bundledSkillsDir(): string {
   return resolve(import.meta.dirname, "..", "..", "skills");
 }
 
-function listSkillNames(root: string): string[] {
-  return readdirSync(root, { withFileTypes: true })
+async function listSkillNames(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true });
+  return entries
     .filter((e) => e.isDirectory())
     .map((e) => e.name)
     .sort();
 }
 
-function isOwnPackageDir(cwdAbsolute: string): boolean {
+async function isOwnPackageDir(cwdAbsolute: string): Promise<boolean> {
   const pkgPath = join(cwdAbsolute, "package.json");
   let raw: string;
   try {
-    raw = readFileSync(pkgPath, "utf8");
+    raw = await readFile(pkgPath, "utf8");
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
     throw new Error(`could not read ${pkgPath}`, { cause: err });
@@ -51,6 +51,15 @@ function isOwnPackageDir(cwdAbsolute: string): boolean {
   return pkg.name === "@nearform/tracebound";
 }
 
+async function readIfExists(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw new Error(`could not read ${path}`, { cause: err });
+  }
+}
+
 export async function runInstallSkills(
   options: InstallSkillsOptions = {},
 ): Promise<InstallSkillsResult> {
@@ -58,7 +67,7 @@ export async function runInstallSkills(
 
   let cwdStat;
   try {
-    cwdStat = statSync(cwdAbsolute);
+    cwdStat = await stat(cwdAbsolute);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       throw new Error(`--cwd path does not exist: ${cwdAbsolute}`);
@@ -73,7 +82,7 @@ export async function runInstallSkills(
 
   const dryRun = options.dryRun ?? false;
 
-  if (isOwnPackageDir(cwdAbsolute)) {
+  if (await isOwnPackageDir(cwdAbsolute)) {
     return {
       cwdAbsolute,
       targetDir: "",
@@ -86,9 +95,20 @@ export async function runInstallSkills(
   }
 
   const bundledDir = bundledSkillsDir();
-  if (!existsSync(bundledDir)) {
+  let bundledStat;
+  try {
+    bundledStat = await stat(bundledDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(
+        `bundled skills directory not found: ${bundledDir}. This CLI install is missing the 'skills/' directory.`,
+      );
+    }
+    throw err;
+  }
+  if (!bundledStat.isDirectory()) {
     throw new Error(
-      `bundled skills directory not found: ${bundledDir}. This CLI install is missing the 'skills/' directory.`,
+      `bundled skills path is not a directory: ${bundledDir}. This CLI install is corrupted.`,
     );
   }
 
@@ -107,16 +127,16 @@ export async function runInstallSkills(
     selfInstallSkipped: false,
   };
 
-  for (const skill of listSkillNames(bundledDir)) {
+  for (const skill of await listSkillNames(bundledDir)) {
     const sourcePath = join(bundledDir, skill, "SKILL.md");
     const targetPath = join(targetDir, skill, "SKILL.md");
 
-    if (!existsSync(sourcePath)) continue;
+    const sourceContents = await readIfExists(sourcePath);
+    if (sourceContents === undefined) continue;
 
-    const sourceContents = readFileSync(sourcePath, "utf8");
-    const targetExists = existsSync(targetPath);
+    const targetContents = await readIfExists(targetPath);
 
-    if (!targetExists) {
+    if (targetContents === undefined) {
       if (!dryRun) {
         await mkdir(dirname(targetPath), { recursive: true });
         await writeFile(targetPath, sourceContents, "utf8");
@@ -125,7 +145,6 @@ export async function runInstallSkills(
       continue;
     }
 
-    const targetContents = readFileSync(targetPath, "utf8");
     if (targetContents === sourceContents) {
       result.upToDate.push(skill);
       continue;

--- a/src/commands/install-skills.ts
+++ b/src/commands/install-skills.ts
@@ -1,0 +1,221 @@
+import {
+  mkdir,
+  readdir,
+  readFile,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { styleText } from "node:util";
+
+export interface InstallSkillsOptions {
+  cwd?: string;
+  target?: string;
+  force?: boolean;
+  dryRun?: boolean;
+}
+
+export interface InstallSkillsResult {
+  /** Absolute path to the resolved cwd. */
+  cwdAbsolute: string;
+  /** Absolute path to the directory skills were copied into. */
+  targetDir: string;
+  /** Skill names copied (or that would be copied in dry-run). */
+  installed: string[];
+  /** Skill names that already match the bundled content. */
+  upToDate: string[];
+  /** Skill names that exist locally with different content and were left untouched. */
+  skipped: string[];
+  /** True when no write was performed because of --dry-run. */
+  dryRun: boolean;
+  /** True when install was skipped because cwd is the tracebound package itself. */
+  selfInstallSkipped: boolean;
+}
+
+export const DEFAULT_TARGET = ".claude/skills/tracebound";
+
+/**
+ * Absolute path to the directory holding the bundled skills in the installed
+ * package. Resolves `<package-root>/skills` regardless of whether this file is
+ * running from `src/commands/` (source/tests) or `dist/commands/` (built CLI).
+ */
+export function bundledSkillsDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, "..", "..", "skills");
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw err;
+  }
+}
+
+async function listSkillNames(skillsRoot: string): Promise<string[]> {
+  const entries = await readdir(skillsRoot, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+}
+
+async function isOwnPackageDir(cwdAbsolute: string): Promise<boolean> {
+  const pkgPath = join(cwdAbsolute, "package.json");
+  try {
+    const raw = await readFile(pkgPath, "utf8");
+    const pkg = JSON.parse(raw) as { name?: unknown };
+    return pkg.name === "@nearform/tracebound";
+  } catch {
+    return false;
+  }
+}
+
+export async function runInstallSkills(
+  options: InstallSkillsOptions = {},
+): Promise<InstallSkillsResult> {
+  const cwdInput = options.cwd ?? process.cwd();
+  const cwdAbsolute = resolve(cwdInput);
+
+  const cwdInfo = await stat(cwdAbsolute).catch((err) => {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`--cwd path does not exist: ${cwdAbsolute}`);
+    }
+    throw err;
+  });
+  if (!cwdInfo.isDirectory()) {
+    throw new Error(`--cwd path is not a directory: ${cwdAbsolute}`);
+  }
+
+  if (await isOwnPackageDir(cwdAbsolute)) {
+    return {
+      cwdAbsolute,
+      targetDir: "",
+      installed: [],
+      upToDate: [],
+      skipped: [],
+      dryRun: options.dryRun ?? false,
+      selfInstallSkipped: true,
+    };
+  }
+
+  const targetRelative = options.target ?? DEFAULT_TARGET;
+  const targetDir = resolve(cwdAbsolute, targetRelative);
+
+  const bundledDir = bundledSkillsDir();
+  if (!(await pathExists(bundledDir))) {
+    throw new Error(
+      `bundled skills directory not found: ${bundledDir}. This CLI install is missing the 'skills/' directory.`,
+    );
+  }
+
+  const dryRun = options.dryRun ?? false;
+  if (!dryRun) {
+    await mkdir(targetDir, { recursive: true });
+  }
+
+  const skills = await listSkillNames(bundledDir);
+  const result: InstallSkillsResult = {
+    cwdAbsolute,
+    targetDir,
+    installed: [],
+    upToDate: [],
+    skipped: [],
+    dryRun,
+    selfInstallSkipped: false,
+  };
+
+  for (const skill of skills) {
+    const sourcePath = join(bundledDir, skill, "SKILL.md");
+    const targetPath = join(targetDir, skill, "SKILL.md");
+
+    if (!(await pathExists(sourcePath))) {
+      continue;
+    }
+
+    const sourceContents = await readFile(sourcePath, "utf8");
+
+    if (!(await pathExists(targetPath))) {
+      if (!dryRun) {
+        await mkdir(dirname(targetPath), { recursive: true });
+        await writeFile(targetPath, sourceContents, "utf8");
+      }
+      result.installed.push(skill);
+      continue;
+    }
+
+    const targetContents = await readFile(targetPath, "utf8");
+    if (targetContents === sourceContents) {
+      result.upToDate.push(skill);
+      continue;
+    }
+
+    if (options.force) {
+      if (!dryRun) {
+        await writeFile(targetPath, sourceContents, "utf8");
+      }
+      result.installed.push(skill);
+      continue;
+    }
+
+    result.skipped.push(skill);
+  }
+
+  return result;
+}
+
+export function reportText(result: InstallSkillsResult): string {
+  const lines: string[] = [];
+
+  if (result.selfInstallSkipped) {
+    lines.push(
+      `${styleText(
+        "dim",
+        `skipped: cwd is the @nearform/tracebound package itself (${result.cwdAbsolute})`,
+      )}`,
+    );
+    return lines.join("\n") + "\n";
+  }
+
+  if (result.installed.length > 0) {
+    for (const skill of result.installed) {
+      const verb = result.dryRun ? "would install" : "installed";
+      lines.push(
+        `${styleText("green", "✓")} ${verb}: ${join(result.targetDir, skill)}`,
+      );
+    }
+  }
+
+  if (result.upToDate.length > 0) {
+    lines.push(
+      `${styleText("dim", `up-to-date: ${result.upToDate.join(", ")}`)}`,
+    );
+  }
+
+  if (result.skipped.length > 0) {
+    for (const skill of result.skipped) {
+      lines.push(
+        `${styleText(
+          "yellow",
+          "!",
+        )} skipped (modified locally, use --force to overwrite): ${join(
+          result.targetDir,
+          skill,
+        )}`,
+      );
+    }
+  }
+
+  lines.push("");
+  lines.push(
+    `${styleText(
+      "dim",
+      `${result.installed.length} installed, ${result.upToDate.length} up-to-date, ${result.skipped.length} skipped`,
+    )} → ${result.targetDir}`,
+  );
+
+  return lines.join("\n") + "\n";
+}


### PR DESCRIPTION
Closes #15

## Summary

Ship the bundled `skills/` tree in the npm package and add a new
`tracebound install-skills` command that copies them into the local
project's skills directory (`.claude/skills/tracebound/` by default).
A `postinstall` hook runs the command as a best-effort default when
the install cwd happens to be a target project.

## Changes

- **`src/commands/install-skills.ts`** (new) — `runInstallSkills()`:
  resolves bundled skills from `<package-root>/skills/`, copies each
  `SKILL.md` into the target directory. Idempotent: identical
  files are reported as up-to-date; locally-edited files are
  reported as skipped and only overwritten with `--force`.
  Detects when `--cwd` is the `@nearform/tracebound` package
  itself (e.g. when the postinstall runs inside the package
  install dir) and exits 0 silently.
- **`src/cli.ts`** — wires up the `install-skills` command,
  argument parsing, and USAGE/help block.
- **`src/__tests__/install-skills.test.ts`** (new) — 10 tests
  covering: bundled-dir resolution, fresh install, idempotency,
  user-edited skills (no overwrite), `--force` overwrite,
  `--dry-run`, custom `--target`, self-install skip, missing-cwd
  and file-cwd rejection.
- **`package.json`** — adds `skills` to `files` so the bundled
  skill tree ships with the npm package; adds a `postinstall`
  script that invokes the CLI in cwd with `|| exit 0` so npm
  install never breaks.
- **`README.md`** — documents the new command in the quickstart
  and CLI reference.

## Acceptance criteria

- [x] After installing the CLI, the skills are present locally with
      no manual download. (Bundled in `files`, copied via the
      `postinstall` hook when cwd is a project, or via the
      `install-skills` command.)
- [x] A command exists to (re)install skills on demand.
      (`tracebound install-skills`.)
- [x] Works when `postinstall` is disabled (fallback command).
      (`tracebound install-skills` is documented as the manual
      fallback.)

## Verification

```
npm run typecheck   # ✓
npm test            # 98 tests pass (10 new)
npm run build       # ✓
node ./dist/cli.js install-skills --help            # ✓
node ./dist/cli.js install-skills --cwd <tmp>       # ✓ installs 4 skills
node ./dist/cli.js install-skills --cwd <tmp>       # ✓ reports up-to-date
node ./dist/cli.js install-skills --cwd <this-repo> # ✓ self-install skip
```